### PR TITLE
Bash:  Auto Setup SSH For GitHub

### DIFF
--- a/auto-git-ssh-setup.sh
+++ b/auto-git-ssh-setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-echo "Auto Git SSH Configuration"
-echo "Author & Source: https://github.com/ZXBYNXK/scripts/bash/git/auto-git-ssh-conf.sh "
+# Source: https://github.com/ZXBYNXK/scripts/bash/auto-git-ssh-setup.sh
 printf "Email: "
 read email
+echo "Generating ssh key for $email"
 ssh-keygen -t rsa -b 4096 -C "$email"
 cat ~/.ssh/id_rsa.pub
 echo "Go to https://github.com/settings/keys and copy then paste the above. (IMPORTANT)"

--- a/auto-git-ssh-setup.sh
+++ b/auto-git-ssh-setup.sh
@@ -1,16 +1,43 @@
 #!/bin/bash
 # Source: https://github.com/ZXBYNXK/scripts/bash/auto-git-ssh-setup.sh
+# Help: https://docs.github.com/en/authentication/connecting-to-github-with-ssh
+
+# Obtain end user email
 printf "Email: "
 read email
-echo "Generating ssh key for $email"
+
+# Generate a ssh key with specified email
+# Info: https://www.ssh.com/academy/ssh/keygen#what-is-ssh-keygen?
+echo "Generating SSH key for $email (Use default values below)"
 ssh-keygen -t rsa -b 4096 -C "$email"
+
+# Show end user their public ssh key and direct them to copy and paste it to the link provided
+echo "------------------------------------------------------------"
 cat ~/.ssh/id_rsa.pub
-echo "Go to https://github.com/settings/keys and copy then paste the above. (IMPORTANT)"
+echo "------------------------------------------------------------"
+echo "Go to https://github.com/settings/keys and copy then paste the above public key. (IMPORTANT)"
+echo "NOTE: Copy text inbetween the dashes!"
+
+# End user needs to complete the above for the below to execute
 printf "Done with the above? (Hit Enter)"
 read none
-echo "Testing SSH to git@github.com ..."
-ssh -T git@github.com || echo "Something is wrong :( **see comments in this file**"
-# (Caution) If test did not work check your input, see 'COMMAND: ...' (i.e. Not found, not installed, unsupported). 
-#  Unfortunately if there is no solution then web search your error logs :("
-# Above git remote commands only needed for existing repos not using SSH (IMPORTANT) Otherwise you are successfully SSH configured.
-# echo Feel free to change this code :) or open an issue @https://github.com/ZXBYNXK/scripts/issues
+
+# Start ssh-agent to manage client authenticity on ssh protocol connections
+# Info: https://www.ssh.com/academy/ssh/agent
+# https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent
+echo "Starting ssh-agent..."
+eval "$(ssh-agent -s)"
+
+# Add the private key into current running ssh-agent
+# Info: https://www.ssh.com/academy/ssh/add
+echo "Adding private key for $email to ssh-agent..."
+ssh-add ~/.ssh/id_rsa
+
+# To avoid client not knowing if ssh connection to github is authentic (May see this when pushing a commit)
+# Info: https://github.com/ome/devspace/issues/38#issuecomment-211515244
+echo "Adding kown_hosts for github (~/.ssh/known_hosts)..."
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Run a test to let the end user know if connection is good
+echo "Testing SSH to git@github.com connection..."
+ssh -T git@github.com || echo "Something is wrong :( >>> See: https://docs.github.com/en/authentication/connecting-to-github-with-ssh"

--- a/auto-git-ssh-setup.sh
+++ b/auto-git-ssh-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo "Auto Git SSH Configuration"
+echo "Author & Source: https://github.com/ZXBYNXK/scripts/bash/git/auto-git-ssh-conf.sh "
+printf "Email: "
+read email
+ssh-keygen -t rsa -b 4096 -C "$email"
+cat ~/.ssh/id_rsa.pub
+echo "Go to https://github.com/settings/keys and copy then paste the above. (IMPORTANT)"
+printf "Done with the above? (Hit Enter)"
+read none
+echo "Testing SSH to git@github.com ..."
+ssh -T git@github.com || echo "Something is wrong :( **see comments in this file**"
+# (Caution) If test did not work check your input, see 'COMMAND: ...' (i.e. Not found, not installed, unsupported). 
+#  Unfortunately if there is no solution then web search your error logs :("
+# Above git remote commands only needed for existing repos not using SSH (IMPORTANT) Otherwise you are successfully SSH configured.
+# echo Feel free to change this code :) or open an issue @https://github.com/ZXBYNXK/scripts/issues

--- a/auto-gpg-verify-download.sh
+++ b/auto-gpg-verify-download.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+output[ask][oks] = "Official key source (https://<URL>/<FILE-NAME>.asc):"
+
+
+main() {
+    
+    ask "OKS"
+}
+
+ask() {
+    if [[ $1 == "OKS" ]]; then
+        printf 
+        read 
+    fi
+}
+
+
+
+# read official_key_source
+# echo "Downloading official key @$official_key_source..."
+# wget -q -O - $official_key_source | gpg --import
+# gpg --fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
+


### PR DESCRIPTION
Added functional [bash script](https://github.com/ZXBYNXK/scripts/blob/main/bash/auto-git-ssh-setup.sh) that automates or helps setting up SSH pushes to GItHub.  So far no issues, will utilize this script for new machines, lost keys, and to help GitHub users  to accomplish this setup at ease.